### PR TITLE
Add support for MongoDB session when adding to queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ queue.add('Hello, World!')
 })
 ```
 
+Add a message to a queue as part of a larger transaction:
+
+```js
+queue.add('Hello, World!', { session: mongoDbSession })
+.then(id => {
+    // Message with payload 'Hello, World!' added.
+    // 'id' is returned, useful for logging.
+})
+```
+
 Get a message from the queue:
 
 ```js

--- a/mongodb-promise-queue.js
+++ b/mongodb-promise-queue.js
@@ -79,6 +79,7 @@ Queue.prototype.createIndexes = function() {
 Queue.prototype.add = function(payload, opts = {}) {
     let delay = opts.delay || this.delay
     let visible = delay ? nowPlusSecs(delay) : now()
+    const session = opts.session || null;
 
     let messages = []
 
@@ -102,7 +103,7 @@ Queue.prototype.add = function(payload, opts = {}) {
         })
     }
 
-    return this.col.insertMany(messages)
+    return this.col.insertMany(messages, { session: session })
     .then(results => {
         return payload instanceof Array ?
             results.insertedIds :


### PR DESCRIPTION
This adds support for transactionally adding messages to queue
as part of a larger operation.